### PR TITLE
Add local URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,3 +44,5 @@ wget -P ./static https://zenodo.org/blablablab/adjacency_matrix_V4.parquet.gzip
 ```
 python app.py
 ```
+
+then open your web browser on <http://127.0.0.1:8050/>


### PR DESCRIPTION
Once the dashboard is running, it's useful to mention its local URL.